### PR TITLE
improved scaffolding and clarified location of words file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,11 +1081,15 @@ problems.
 Verify that a file exists on the courseware VM called
 `/usr/share/dict/words`.  What's in it?
 
+(Note: if this file doesn't exist, you can install it on Ubuntu 14 by
+typing `sudo apt-get install --reinstall wamerican`.  On other
+distributions or non-Linux versions of Unix, the file may be 
+[elsewhere](http://objectroot.org/articles/brief-history-of-hier/), or
+absent. 
+
 > This file has been part of Unix since almost 
-> [the beginning of time](http://en.wikipedia.org/wiki/Unix_time), 
-> although it 
-> [has moved around](http://objectroot.org/articles/brief-history-of-hier/) 
-> since then.  It has been used by programs ranging from spelling
+> [the beginning of time](http://en.wikipedia.org/wiki/Unix_time).
+> It has been used by programs ranging from spelling
 > checkers to password guessers.
 
 Why do you think we used a remote SOA endpoint to generate random words

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,0 +1,73 @@
+require 'sinatra/base'
+require 'sinatra/flash'
+require './lib/hangperson_game.rb'
+
+class HangpersonApp < Sinatra::Base
+
+  enable :sessions
+  register Sinatra::Flash
+  
+  before do
+    # code that is called before EVERY HTTP request
+  end
+  
+  after do
+    # code that is called after EVERY HTTP request
+  end
+  
+  get '/' do
+    redirect '/new'
+  end
+  
+  get '/new' do
+    erb :new
+  end
+  
+  post '/create' do
+    # Don't change next line: it's necessary for autograder to work properly.
+    word = params[:word] || HangpersonGame.get_random_word # don't change this line!
+    # Don't change the above line: it's necessary for autograder to work properly.
+    # Your additional code goes here:
+
+  end
+  
+  post '/guess' do
+    # get the guessed letter from params[:guess] (note: if user left it blank,
+    #   params[:guess] will be nil)
+
+    # Try guessing the letter.  If it has already been guessed,
+    #   display "You have already used that letter."
+
+    # Either way, the user should then be shown the main game screen ('show' action).
+
+  end
+  
+  get '/show' do
+    # To show the game status, use the check_win_or_lose function.
+    # If player wins (word completed), do the 'win' action instead.
+    # If player loses (all guesses used), do the 'lose' action instead.
+    # Otherwise, show the contents of the 'show.erb' (main game view) template.
+
+  end
+  
+  get '/win' do
+    # Player wins. WARNING: prevent cheating by making sure the game has really been won!
+    #  If player tries to cheat, they should be shown the main game view instead.  (And
+    #  you can optionally supply a "No cheating!" messaage.)
+    # If they really did win, show the 'win' view template.
+    
+  end
+  
+  get '/lose' do
+    # Player loses. WARNING: make sure the game has really been lost!
+    # If they really did lose, show the 'win' view template.
+    # Otherwise, show the main game view instead.
+
+    if @game.check_win_or_lose == :lose
+      erb :lose
+    else
+      redirect '/show'
+    end
+  end
+  
+end

--- a/views/new.erb
+++ b/views/new.erb
@@ -1,3 +1,4 @@
+<!-- This form is incomplete--it needs a destination URL as well as a method: -->
 <form method="post">
   <input type="submit" value="New Game"/>
 </form>


### PR DESCRIPTION
The scaffolding in app.rb was totally bare; I added some scaffolding that's consistent with the README.  I also clarified the location of `/usr/share/dict/words` in the "extra credit" section of the assignment, since the Cloud9 install script doesn't install by default the package that provides this file.  (I updated the c9setup script to do this in the future.)