### PR TITLE
Use `bundle exec autotest` instead of `autotest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ block" in a **Service-Oriented Architecture**, but also how a Cucumber
 scenario can test such an app deterministically with tests that
 **break the dependency** on the external service at testing time.
 
-* In the app's root directory, say `autotest`.  
+* In the app's root directory, say `bundle exec autotest`.  
 
 This will fire up the Autotest framework, which looks for various files
 to figure out what kind of app you're testing and what test framework


### PR DESCRIPTION
Here it is without `bundle exec`:
```
$ autotest
(Not running features.  To run features in autotest, set AUTOFEATURE=true.)
loading autotest/rspec_rspec2
Autotest style autotest/rspec_rspec2 doesn't seem to exist. Aborting.
```