### PR TITLE
add text file preparation instructions

### DIFF
--- a/docs/part_6_conclusion.md
+++ b/docs/part_6_conclusion.md
@@ -34,6 +34,24 @@ as "templates" capturing an effective solution to a class of similar
 problems. 
 
 
+Homework Submission
+==========
+IMPORTANT!!! The file that you will submit to the autograder MUST be ASCII encoded. If you do not know what this means then please create your text file in cloud9 using the `echo` command like this:
+```
+echo 'my-app-12345.herokuapp.com' > hw2.txt
+```
+Note that the auto-grader expects the URL to be of a specific form - the URL in the text file should contain neither http:// nor https://. If you run the `cat` command after creating the file like this:
+```
+cat hw2.txt
+```
+then the output should look like this:
+```
+my-app-12345.herokuapp.com
+```
+You would of course change 'my-app-12345' to match your heroku URL. Then right-click on the 'hw2.txt' file in the left side panel of cloud9 and choose 'Download'. Remember which folder you download this into so that you can browse for it on the homework submission page. It is usually your 'My Downloads' folder.
+
+Lastly, visit the same URL that you put into the text file with your web browser to be sure that your app is running correctly at that address before submitting the text file.
+
 -----
 
 Next: [Optional Challenge Assignment](part_7_optional_challenge.md)  


### PR DESCRIPTION
despite the rather clear instructions on the submission page many students are still using their local text editors or echo in their mac terminal which usually produces unicode - they result in various grader errors or some complete successfully but with erroneous results - this is quite time consuming to diagnose especially because the text file may be the last likely culprit in some cases

there is a diverse collection of pathological text files on issue #20 so maybe the grader can be made more robust against these - but for now we should probably add something of this sort either in the spec or on the submission page - at least the line "IMPORTANT!!! The file that you will submit to the autograder MUST be ASCII encoded. If you do not know what this means then please create your text file in cloud9 using the `echo` command"