### PR TITLE
reverted instructions to fork and clone

### DIFF
--- a/docs/part_0_create_saas_app.md
+++ b/docs/part_0_create_saas_app.md
@@ -260,9 +260,13 @@ how to start your Sinatra app.  How do you tell a production environment how to 
 necessary to receive requests and start your app?  In the case of Heroku, this is done with a special file named `Procfile`, 
 which specifies one or more types of Heroku processes your app will use, and how to start each one.
 The most basic Heroku process type is called a Dyno, or "web worker".  One Dyno can serve one user request at a time.  Since
-we're on Heroku's free tier, we can only have one Dyno.  Take a look in the `Procfile` and you'll see that it tells Heroku
-to start a single web worker (Dyno) using essentially the same command line you used to start Rack locally.  The `Procfile` is
-important because without it, Heroku won't know how to start your app.
+we're on Heroku's free tier, we can only have one Dyno. Let's create a file named `Procfile`, and only this as the name (i.e. Procfile.txt is not valid). Write the following line in your `Procfile`:
+
+```
+web: bundle exec rackup config.ru -p $PORT
+```
+
+This tells Heroku to start a single web worker (Dyno) using essentially the same command line you used to start Rack locally. Note that in some cases, a `Procfile` is not necessary since Heroku can infer from your files how to start the app. However, it's always better to be explicit.
 
 Your local Cloud9 repo is now ready to deploy to Heroku:
 

--- a/docs/part_1_hangperson.md
+++ b/docs/part_1_hangperson.md
@@ -1,10 +1,11 @@
 
 Part 1: Hangperson
 ===========================================================================
-With all this machinery in mind, clone this repo into Cloud9, and let's work on Hangperson.
+With all this machinery in mind, fork this repo into your GitHub, and let's 
+work on Hangperson. Get your clone URL from your fork and go to Cloud9.
 
 ```sh
-$ git clone https://github.com/saasbook/hw-sinatra-saas-hangperson
+$ git clone <insert the clone url from your github fork of this repo here>
 $ cd hw-sinatra-saas-hangperson
 $ bundle
 ```


### PR DESCRIPTION
If a student forks first, s/he can push code back to GitHub instead of only committing locally. Up to you guys.

[Relevant commit](https://github.com/saasbook/hw-sinatra-saas-hangperson/commit/53ae987206de72e94a9d9bb7b95d3858bb9dda58)
