### PR TITLE
Changed get_random_word to work with a proxy

### DIFF
--- a/lib/hangperson_game.rb
+++ b/lib/hangperson_game.rb
@@ -12,11 +12,16 @@ class HangpersonGame
     @word = word
   end
 
+  # You can test it by running $ bundle exec irb -I. -r app.rb
+  # And then in the irb: irb(main):001:0> HangpersonGame.get_random_word
+  #  => "cooking"   <-- some random word
   def self.get_random_word
     require 'uri'
     require 'net/http'
     uri = URI('http://watchout4snakes.com/wo4snakes/Random/RandomWord')
-    Net::HTTP.post_form(uri ,{}).body
+    Net::HTTP.new('watchout4snakes.com').start { |http|
+      return http.post(uri, "").body
+    }
   end
 
 end


### PR DESCRIPTION
This change makes the POST request take into account ENV['http_proxy'] variable.
This is important when the code runs behind a proxy. The post_form ignores
the proxy variable, the new method uses the proxy.

Also a comment is added for people wanting to test it right, as curl method
might not be enough.