### PR TITLE
Fix a bug in cucumber specification

### DIFF
--- a/features/game_over.feature
+++ b/features/game_over.feature
@@ -14,5 +14,5 @@ Scenario: game over because I run out of guesses
 
   Given I start a new game with word "zebra"
   When I make the following guesses: t,u,v,w,x,y
-  And I guess "z"
+  And I guess "d"
   Then I should see "Sorry, you lose!"


### PR DESCRIPTION
The game specification is that seven wrong answers to fail the game. Here 'z' is a correct guess, so it should not fail the game.

This bug is in PR #31 .