### PR TITLE
Fixed typo "by rerun byagain refreshing"

### DIFF
--- a/docs/part_0_create_saas_app.md
+++ b/docs/part_0_create_saas_app.md
@@ -149,7 +149,7 @@ Say `bundle exec rerun -- rackup -p $PORT -o $IP` in the terminal window to star
 
 In this case we are prefixing with `bundle exec` again in order to ensure we are using the gems in the Gemfile.lock, and the `--` symbol is there to assert that the command we want rerun to operate with is `rackup -p $PORT -o $IP`.  We could achieve the same effect with `bundle exec rerun "rackup -p $PORT -o $IP"`.  They are equivalent.   More importantly any detected changes will now cause the server to restart automatically, similar to the use of `guard` to auto re-run specs when files change.
 
-Modify `app.rb` to print a different message, and verify that the change is detected by rerun byagain refreshing your browser tab with the running app.  Also before we move on you should commit your latest changes to git.
+Modify `app.rb` to print a different message, and verify that the change is detected by refreshing your browser tab with the running app.  Also before we move on you should commit your latest changes to git.
 
 Deploy to Heroku
 ----------------


### PR DESCRIPTION
The rerun command was executed before, so a simple browser refresh should do the trick.