### PR TITLE
remove c9 reference in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Prerequisites
 * You should be familiar with Ruby basics, for example by completing the Ruby Intro or Ruby Calisthenics assignment.
 * You should have read [ESaaS](http://www.saasbook.info) Chapter 2, "The Architecture of SaaS Applications", and watched the accompanying videos in the [MOOC](http://www.saas-class.org).
 * You should be comfortable with basic Git usage and how to push your code to GitHub, as described in Appendix A of [ESaaS](http://www.saasbook.info).
-* You will need "survival level" Unix command-line skills and facility with an editor to edit code files, such as the built-in editor in the Cloud9 IDE.
+* You will need "survival level" Unix command-line skills and facility with an editor to edit code files.
 
 **NOTE: You may find the [Sinatra documentation](https://sinatrarb.com) helpful to have on hand.**
 

--- a/docs/part_0_create_saas_app.md
+++ b/docs/part_0_create_saas_app.md
@@ -8,7 +8,7 @@ Part 0: Demystifying SaaS app creation
 Creating and versioning a simple SaaS app
 -----------------------------------------
 
-SaaS apps are developed on your computer (or cloud-based IDE) but *deployed to production* on a server that others can access.  We try to minimize the differences between the development and production *environments*, to avoid difficult-to-diagnose problems in which something works one way on your development computer but a different way (or not at all) when that code is deployed to production.
+SaaS apps are developed on your computer but *deployed to production* on a server that others can access.  We try to minimize the differences between the development and production *environments*, to avoid difficult-to-diagnose problems in which something works one way on your development computer but a different way (or not at all) when that code is deployed to production.
 
 We have two mechanisms for keeping the development and production environments consistent.  The first is *version control*, such as Git, for the app's code.  But since almost all apps also rely on *libraries* written by others, such as *gems* in the case of Ruby, we need a way to keep track of which versions of which libraries our app has been tested with, so that the same ones are used in development and production.
 
@@ -107,16 +107,9 @@ If you're developing locally, you're now ready to test-drive our simple app with
 $ bundle exec rackup
 ```
 
-If you're using Cloud9, you should use this command line:
-
-```sh
-$ bundle exec rackup -p $PORT -o $IP
-```
-[Available ports on a hosted Cloud9 workspace](https://docs.c9.io/docs/run-an-application)
-
 This command starts the Rack appserver and the WEBrick webserver.  Prefixing it with `bundle exec` ensures that you are running with the gems specified in `Gemfile.lock`.  Rack will look for `config.ru` and attempt to start our app based on the information there.
 
-If you're developign locally, you can visit `localhost:9292` in your browser to see the webapp.  If you're using Cloud9, you will see a small popup in the terminal with a URL to your running webapp.  It will open in a new tab in the IDE if you click on it, but you should open up a fresh browser tab and paste in that URL.
+If you're developign locally, you can visit `localhost:9292` in your browser to see the webapp. It will open in a new tab in the IDE if you click on it, but you should open up a fresh browser tab and paste in that URL.
 
 Point a new Web browser tab at the running app's URL and verify that you can see "Hello World".
 
@@ -134,11 +127,11 @@ You should now have the following files under version control: `Gemfile`, `Gemfi
 Modify the app
 --------------
 
-Modify `app.rb` so that instead of "Hello World" it prints "Goodbye World". Save your changes to `app.rb` and try refreshing your browser tab where the app is running.  
+Modify `app.rb` so that instead of "Hello World" it prints "Goodbye World". Save your changes to `app.rb` and try refreshing your browser tab where the app is running.
 
 No changes? Confused?
 
-Now go back to the shell window where you ran `rackup` and press Ctrl-C to stop Rack.  Then type `bundle exec rackup` again (`bundle exec rackup -p $PORT -o $IP`, for Cloud9), and once it is running, go back to your browser tab with your app and refresh the page.  This time it should work.
+Now go back to the shell window where you ran `rackup` and press Ctrl-C to stop Rack.  Then type `bundle exec rackup` again, and once it is running, go back to your browser tab with your app and refresh the page.  This time it should work.
 
 What this shows you is that if you modify your app while it's running, you have to restart Rack in order for it to "see" those changes.  Since restarting it manually is tedious, we'll use the `rerun` gem, which restarts Rack automatically when it sees changes to files in the app's directory. (Rails does this for you by default during development, as we'll see, but Sinatra doesn't.)
 
@@ -160,15 +153,9 @@ Modify `app.rb` to print a different message, and verify that the change is dete
 
 Deploy to Heroku
 ----------------
-Heroku is a cloud platform-as-a-service (PaaS) where we can deploy our Sinatra (and later Rails) applications in a more robust way than via Cloud9. If you don't have an account yet, go sign up at http://www.heroku.com. You'll need your login and password for the next step.
+Heroku is a cloud platform-as-a-service (PaaS) where we can deploy our Sinatra (and later Rails) applications. If you don't have an account yet, go sign up at http://www.heroku.com. You'll need your login and password for the next step.
 
-If you're developing locally, install Heroku CLI following [instructions](https://devcenter.heroku.com/articles/heroku-cli).
-
-If using Cloud9, update your Heroku Toolbelt installation by typing the following command:
-
-```
-$ wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
-```
+Install Heroku CLI following [instructions](https://devcenter.heroku.com/articles/heroku-cli).
 
 Log in to your Heroku account by typing the command: `heroku login -i` in the terminal. This will connect you to your Heroku account.
 
@@ -182,7 +169,7 @@ Earlier we saw that to run the app locally you run `rackup` to start the Rack ap
 web: bundle exec rackup config.ru -p $PORT
 ```
 
-This tells Heroku to start a single web worker (Dyno) using essentially the same command line you used to start Rack locally. Note that in some cases, a `Procfile` is not necessary since Heroku can infer from your files how to start the app. However, it's always better to be explicit.  
+This tells Heroku to start a single web worker (Dyno) using essentially the same command line you used to start Rack locally. Note that in some cases, a `Procfile` is not necessary since Heroku can infer from your files how to start the app. However, it's always better to be explicit.
 
 Your local repo is now ready to deploy to Heroku:
 
@@ -190,7 +177,7 @@ Your local repo is now ready to deploy to Heroku:
 $ git push heroku master
 ```
 
-(`master` refers to which branch of the remote Heroku repo we are pushing to.  We'll learn about branches later in the course, but for now, suffice it to say that you can only deploy to the `master` branch on Heroku.) This push will create a running instance of your app at some URL ending with `herokuapp.com`. Enter that URL in a new browser tab (not in the Cloud9 IDE) to see your app running live. Congratulations, you did it--your app is live!
+(`master` refers to which branch of the remote Heroku repo we are pushing to.  We'll learn about branches later in the course, but for now, suffice it to say that you can only deploy to the `master` branch on Heroku.) This push will create a running instance of your app at some URL ending with `herokuapp.com`. Enter that URL in a new browser tab to see your app running live. Congratulations, you did it--your app is live!
 
 Summary
 -------

--- a/docs/part_3_connecting_hangperson_to_sinatra.md
+++ b/docs/part_3_connecting_hangperson_to_sinatra.md
@@ -7,7 +7,7 @@ You've already met Sinatra.  Here's what's new in the Sinatra app skeleton [`app
 * `before do...end` is a block of code executed *before* every SaaS request
 
 * `after do...end` is executed *after* every SaaS request
- 
+
 * The calls  `erb :` *action* cause Sinatra to look for the file `views/`*action*`.erb` and run them through the Embedded Ruby processor, which looks for constructions `<%= like this %>`, executes the Ruby code inside, and substitutes the result.  The code is executed in the same context as the call to `erb`, so the code can "see" any instance variables set up in the `get` or `post` blocks.
 
 #### Self Check Question
@@ -27,7 +27,7 @@ If the game object were large, we'd probably store it in a database on the serve
 
 There is one other session-like object we will use.  In some cases above, one action will perform some state change and then redirect to another action, such as when the Guess action (triggered by `POST /guess`) redirects to the Show action (`GET /show`) to redisplay the game state after each guess.  But what if the Guess action wants to display a message to the player, such as to inform them that they have erroneously repeated a guess?  The problem is that since every request is stateless, we need to get that message "across" the redirect, just as we need to preserve game state "across" HTTP requests.
 
-To do this, we use the `sinatra-flash` gem, which you can see in the Gemfile.  `flash[]` is a hash for remembering short messages that persist until the *very next* request (usually a redirect), and are then erased. 
+To do this, we use the `sinatra-flash` gem, which you can see in the Gemfile.  `flash[]` is a hash for remembering short messages that persist until the *very next* request (usually a redirect), and are then erased.
 
 #### Self Check Question
 
@@ -40,18 +40,17 @@ messages in the <code>session[]</code> hash?</summary>
 Running the Sinatra app
 -----------------------
 
-As before, run the shell command `bundle exec rackup` (`bundle exec rackup -p $PORT -o $IP` for Cloud9) to start the app, or `bundle exec rerun -- rackup` (`bundle exec rerun -- rackup -p $PORT -o $IP` for Cloud9) if you want to rerun the app each time you make a code change.  
+As before, run the shell command `bundle exec rackup` to start the app, or `bundle exec rerun -- rackup` if you want to rerun the app each time you make a code change.
 
 #### Self Check Question
 
 <details>
   <summary>Based on the output from running this command, what is the full URL you need to visit in order to visit the New Game page?</summary>
   <p><blockquote>The Ruby code <code>get '/new' do...</code> in <code>app.rb</code> renders the New Game page, so the full URL is in the form <code>http://localhost:9292/new</code></p>
-  <p><blockquote>If you are developing on Cloud9, the URL is something like <code>http://your-workspace-name.c9.io/new</code>.</blockquote></p>
 </details>
 <br />
 
-Visit this URL and verify that the Start New Game page appears. 
+Visit this URL and verify that the Start New Game page appears.
 
 #### Self Check Question
 
@@ -69,10 +68,10 @@ But first, let's get our app onto Heroku.  This is actually a critical step.  We
 * Next, type `git add .` to stage all changed files (including Gemfile.lock)
 * Then type `git commit -m "Ready for Heroku!"` to commit all local changes.
 * Next, type `heroku login` and authenticate.
-* Since this is the first time we're telling Heroku about the Hangperson app, we must type `heroku create` to have Heroku prepare to recieve this code and to have it create a git reference for referencing the new remote repository. 
-* Then, type `git push heroku master` to push your code to Heroku. 
-* When you want to update Heroku later, you only need to commit your changes to git locally, then push to Heroku as in the last step. 
-* Verify that the Heroku-deployed Hangperson behaves the same as your development version before continuing. A few lines up from the bottom of the Heroku output in the terminal should have a URL ending in herokuapp.com. Find that, copy it to the clipboard, and paste it into a browser tab to see the current app. The Cloud9 IDE browser tab won't render the app properly, so use a new browser tab outside of Cloud9.
+* Since this is the first time we're telling Heroku about the Hangperson app, we must type `heroku create` to have Heroku prepare to recieve this code and to have it create a git reference for referencing the new remote repository.
+* Then, type `git push heroku master` to push your code to Heroku.
+* When you want to update Heroku later, you only need to commit your changes to git locally, then push to Heroku as in the last step.
+* Verify that the Heroku-deployed Hangperson behaves the same as your development version before continuing. A few lines up from the bottom of the Heroku output in the terminal should have a URL ending in herokuapp.com. Find that, copy it to the clipboard, and paste it into a browser tab to see the current app.
 * Verify the broken functionality by clicking the new game button.
 
 -----

--- a/docs/part_4_cucumber.md
+++ b/docs/part_4_cucumber.md
@@ -89,7 +89,7 @@ Now stage and commit all files locally, then `git push heroku master` to deploy 
 Develop the scenario for guessing a letter
 -------------------------------------------
 
-For this scenario, in `features/guess.feature`, we've already provided a correct  `show.erb` HTML file that submits the player's guess to the `guess` action.  You already have a `HangpersonGame#guess` instance method that has the needed functionality.  
+For this scenario, in `features/guess.feature`, we've already provided a correct  `show.erb` HTML file that submits the player's guess to the `guess` action.  You already have a `HangpersonGame#guess` instance method that has the needed functionality.
 
 #### Self Check Question
 
@@ -118,7 +118,7 @@ While you're here, read the comments in the file. They give clues for future ste
 
 When finished adding that code, verify that all the steps in `features/guess.feature` now pass by running cucumber for that .feature file.
 
-* Debugging tip: The Capybara command `save_and_open_page` placed in a step definition will cause the step to open a Web browser window showing what the page looks like at that point in the scenario.  The functionality is provided in part by a gem called `launchy` which is in the Gemfile.  NOTE: to run `launchy` on c9 you first need to run `sudo apt-get install iceweasel`
+* Debugging tip: The Capybara command `save_and_open_page` placed in a step definition will cause the step to open a Web browser window showing what the page looks like at that point in the scenario.  The functionality is provided in part by a gem called `launchy` which is in the Gemfile.
 
 -----
 

--- a/docs/part_5_corner_cases.md
+++ b/docs/part_5_corner_cases.md
@@ -41,8 +41,6 @@ my-app-12345.herokuapp.com
 
 You would of course change 'my-app-12345' to match your heroku URL.
 
-If you're using Cloud9, right-click on the 'hw2.txt' file in the left side panel of Cloud9 and choose 'Download'. Remember which folder you download this into so that you can browse for it on the homework submission page. It is usually your 'My Downloads' folder.
-
 Lastly, visit the same URL that you put into the text file with your web browser to be sure that your app is running correctly at that address before submitting the text file.
 
 -----


### PR DESCRIPTION
Removing references to Cloud9

```
2. Can I create a new account on c9.io?
No, we are no longer accepting new account signups on c9.io.
```

from https://c9.io/announcement